### PR TITLE
Quick fix for Cougar Hide Wrap CraftingIcon not displaying

### DIFF
--- a/CraftingRevisions/BuildInfo.cs
+++ b/CraftingRevisions/BuildInfo.cs
@@ -6,7 +6,7 @@
 		public const string Description = "A mod that improves the Crafting & Cooking system."; // Description for the Mod.  (Set as null if none)
 		public const string Author = "STBlade"; // Author of the Mod.  (MUST BE SET)
 		public const string Company = null; // Company that made the Mod.  (Set as null if none)
-		public const string Version = "2.3.1"; // Version of the Mod.  (MUST BE SET)
+		public const string Version = "2.3.2"; // Version of the Mod.  (MUST BE SET)
 		public const string DownloadLink = null; // Download Link for the Mod.  (Set as null if none)
 	}
 }

--- a/CraftingRevisions/CraftingMenu/CraftingMenuPatches.cs
+++ b/CraftingRevisions/CraftingMenu/CraftingMenuPatches.cs
@@ -119,7 +119,12 @@ namespace CraftingRevisions.CraftingMenu
 
                 __instance.m_BlueprintData= bpi;
 				__instance.m_CanCraftBlueprint = panel.CanCraftBlueprint(bpi);
-				string text = bpi.m_CraftedResult.name.Replace("GEAR_", "ico_CraftItem__");
+				
+				// For some reason Hinterland decided to name the GEAR item differently from it's CraftingItem icon, so it wasn't displaying.
+				// This will fix that, but if other items pop-up in the future we will have to reconsider this approach.
+				// Deadman was here :)
+				string text = bpi.m_CraftedResult.name is "GEAR_CougarWrap" ? "ico_CraftItem__CougarHideWrap" : bpi.m_CraftedResult.name.Replace("GEAR_", "ico_CraftItem__");
+				
 				__instance.m_Icon.mainTexture = Addressables.LoadAssetAsync<Texture2D>(text).WaitForCompletion();
 				__instance.m_Icon.enabled = true;
 				__instance.m_DisplayName.text = bpi.GetDisplayedNameWithCount();

--- a/CraftingRevisions/CraftingRevisions.csproj
+++ b/CraftingRevisions/CraftingRevisions.csproj
@@ -27,7 +27,7 @@
 	<!--This is for NuGet.-->
 	<PropertyGroup>
 		<Authors>STBlade</Authors>
-		<Version>2.3.1</Version>
+		<Version>2.3.2</Version>
 		<AssemblyVersion>$(Version)</AssemblyVersion>
 		<PackageId>STBlade.Modding.TLD.CraftingRevisions</PackageId>
 		<PackageTags>MelonLoader Modding TLD Json Blueprint Crafting Utility Mod</PackageTags>


### PR DESCRIPTION
Basically what the title is, Hinterland made a mistake of not naming the Cougar Hide Wrap CraftingIcon the same as the GEAR item name - so it isn't displaying because it can't find it. This should fix it.